### PR TITLE
Incorporate memberid updates

### DIFF
--- a/api/utterances/get-all.js
+++ b/api/utterances/get-all.js
@@ -18,6 +18,7 @@ module.exports = async(req, res) => {
         seq,
         speech,
         start,
+        start_timestamp,
         duration,
         confidence,
         member_id

--- a/client/src/components/Utterances.js
+++ b/client/src/components/Utterances.js
@@ -280,7 +280,7 @@ class Utterances extends Component {
                   }
                   <UtterTable.Tr>
                     <UtterTable.Td>
-                      {formatTimeDurationMMMSS(u.start)}
+                      {formatTimeDurationMMMSS(timeDifference(this.state.transInfo.time_start,u.start_timestamp))}
                     </UtterTable.Td>
                     <UtterTable.Td>{u.speech}</UtterTable.Td>
                     <UtterTable.Td>{formatTimeDuration(u.duration, 1)}</UtterTable.Td>

--- a/client/src/components/Utterances.js
+++ b/client/src/components/Utterances.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import axios from 'axios';
-import { datetime, timeOnly, dateOnly, timeDifference, isSameDate, formatTimeDuration, formatTimeDurationHMM, getTimeOffset } from '../util/date-format';
+import { datetime, timeOnly, dateOnly, timeDifference, isSameDate, formatTimeDuration, formatTimeDurationMMMSS, getTimeOffset } from '../util/date-format';
 import Main from '../styles/Main';
 import H1 from '../styles/H1';
 import A from '../styles/A';
@@ -280,7 +280,7 @@ class Utterances extends Component {
                   }
                   <UtterTable.Tr>
                     <UtterTable.Td>
-                      {formatTimeDurationHMM(u.start)}
+                      {formatTimeDurationMMMSS(u.start)}
                     </UtterTable.Td>
                     <UtterTable.Td>{u.speech}</UtterTable.Td>
                     <UtterTable.Td>{formatTimeDuration(u.duration, 1)}</UtterTable.Td>

--- a/client/src/util/date-format.js
+++ b/client/src/util/date-format.js
@@ -35,12 +35,6 @@ const timeOnly = (date) => {
   return `${d.hour}:${d.min}${d.ampm}`
 };
 
-const timeWithSeconds = (date) => {
-  if (!date) return false;
-  const d = breakDownDate(date);
-  return `${d.hour}:${d.min}:${d.sec}${d.ampm}`
-};
-
 const dateOnly = (date) => {
   if (!date) return false;
   const d = breakDownDate(date);
@@ -119,7 +113,6 @@ const getTimeOffset = (date, offset) => {
 export {
   datetime,
   timeOnly,
-  timeWithSeconds,
   dateOnly,
   isSameDate,
   timeDifference,

--- a/client/src/util/date-format.js
+++ b/client/src/util/date-format.js
@@ -95,7 +95,7 @@ const formatTimeDuration = (durationInSeconds, numberDecimals) => {
     `${sec}s`;
 };
 
-const formatTimeDurationHMM = (durationInSeconds) => {
+const formatTimeDurationMMMSS = (durationInSeconds) => {
   if (parseFloat(durationInSeconds) === 0) return '0:00';
   if (!durationInSeconds) return false;
   let min = Math.floor(durationInSeconds / 60);
@@ -124,6 +124,6 @@ export {
   isSameDate,
   timeDifference,
   formatTimeDuration,
-  formatTimeDurationHMM,
+  formatTimeDurationMMMSS,
   getTimeOffset,
 };

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -26,6 +26,7 @@ CREATE TABLE `utterances`
     `seq`               INT NOT NULL,
     `speech`            TEXT NOT NULL,
     `start`             DECIMAL(12,6),
+    `start_timestamp`   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     `duration`          DECIMAL(12,6),
     `confidence`        DECIMAL(12,6),
     `member_id`         INT,

--- a/test/voip/add-utterance.js
+++ b/test/voip/add-utterance.js
@@ -86,6 +86,9 @@ test('VoIP > Add Utterance', async(t) => {
       method: 'GET',
       uri: '/trans/1/utter',
     });
+    response.body.forEach(utter => {
+      delete utter.start_timestamp;
+    });
     t.deepEqual(
       response.body,
       [


### PR DESCRIPTION
Implement the following changes:
* display member ID on utterances view (adjust so that lowest member ID is 1)
* add timestamp into database when utterances are created
* display utterance time by calculating difference between transcription start time and utterance timestamp (instead of by start offset provided by telephony app)