### PR TITLE
Client bug fix and code optimization

### DIFF
--- a/client/src/components/Conferences.js
+++ b/client/src/components/Conferences.js
@@ -103,6 +103,7 @@ class Conferences extends Component {
     this.setState({
       modalDisplayed: '',
       confBeingModified: null,
+      rowHighlighted: null,
     })
   }
   async refreshAfterSave() {
@@ -111,6 +112,7 @@ class Conferences extends Component {
       conferences: conferencesResults.data,
       modalDisplayed: '',
       confBeingModified: null,
+      rowHighlighted: null,
     })
   }
   closeEverything(e) {

--- a/client/src/components/Conferences.js
+++ b/client/src/components/Conferences.js
@@ -35,6 +35,7 @@ class Conferences extends Component {
     this.addConference = this.addConference.bind(this);
     this.cancelForm = this.cancelForm.bind(this);
     this.refreshAfterSave = this.refreshAfterSave.bind(this);
+    this.closeEverything = this.closeEverything.bind(this);
   }
   toggleConfMenu(id, e) {
     e.stopPropagation();
@@ -112,25 +113,24 @@ class Conferences extends Component {
       confBeingModified: null,
     })
   }
-  async componentDidMount() {
-    window.addEventListener('click', () => {
+  closeEverything(e) {
+    if (!e.key || e.key === 'Escape' || e.key === 'Esc') {
       this.setState({
         modalDisplayed: '',
         rowHighlighted: null,
       });
       this.closeAllMenus();
-    });
-    window.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape' || e.key === 'Esc') {
-        this.setState({
-          modalDisplayed: '',
-          rowHighlighted: null,
-        });
-        this.closeAllMenus();
-      }
-    });
+    }
+  }
+  async componentDidMount() {
+    window.addEventListener('click', this.closeEverything);
+    window.addEventListener('keydown', this.closeEverything);
     const conferencesResults = await axios.get('/api/conf');
     this.setState({ conferences: conferencesResults.data });
+  }
+  componentWillUnmount() {
+    window.removeEventListener('click', this.closeEverything);
+    window.removeEventListener('keydown', this.closeEverything);
   }
   render() {
     return (

--- a/client/src/components/Conferences.js
+++ b/client/src/components/Conferences.js
@@ -179,17 +179,17 @@ class Conferences extends Component {
                   allowHighlight={!this.state.rowHighlighted}
                 >
                   <Table.Td>
-                    <Table.A href={`/conf/${c.id}`}>{c.meeting_pin}</Table.A>
+                    <Table.StyledLink to={`/conf/${c.id}`}>{c.meeting_pin}</Table.StyledLink>
                   </Table.Td>
                   <Table.Td grow>
-                    <Table.A href={`/conf/${c.id}`}>
+                    <Table.StyledLink to={`/conf/${c.id}`}>
                       {c.description || <span>&nbsp;</span>}
                       {c.freeswitch_ip &&
                         <Table.Span blue title="There is currently an active call on this conference">
                           (Active)
                         </Table.Span>
                       }
-                    </Table.A>
+                    </Table.StyledLink>
                   </Table.Td>
                   <Table.Td>
                     <Table.Button
@@ -203,21 +203,25 @@ class Conferences extends Component {
                     {
                       c.showMenu
                         ? <Menu.Menu>
-                            <Menu.Link as="a" href={`/conf/${c.id}`}>
+                            <Menu.StyledLink to={`/conf/${c.id}`}>
                               View Transcriptions
-                            </Menu.Link>
-                            <Menu.Link
+                            </Menu.StyledLink>
+                            <Menu.StyledLink
+                              to=""
+                              as="button"
                               onClick={this.editConference.bind(this, c)}
                               disabled={this.state.modalDisplayed}
                             >
                               Edit Conference
-                            </Menu.Link>
-                            <Menu.Link
+                            </Menu.StyledLink>
+                            <Menu.StyledLink
+                              to=""
+                              as="button"
                               onClick={this.deleteConference.bind(this, c)}
                               disabled={this.state.modalDisplayed}
                             >
                               Delete Conference
-                            </Menu.Link>
+                            </Menu.StyledLink>
                           </Menu.Menu>
                         : null
                     }

--- a/client/src/components/Transcriptions.js
+++ b/client/src/components/Transcriptions.js
@@ -73,6 +73,7 @@ class Transcriptions extends Component {
     this.setState({
       modalDisplayed: '',
       transcriptionBeingModified: null,
+        rowHighlighted: null,
     })
   }
   async refreshAfterSave() {
@@ -82,6 +83,7 @@ class Transcriptions extends Component {
       transcriptions: transcriptions.data,
       modalDisplayed: '',
       transcriptionBeingModified: null,
+      rowHighlighted: null,
     })
   }
   sortReverse() {

--- a/client/src/components/Transcriptions.js
+++ b/client/src/components/Transcriptions.js
@@ -30,6 +30,7 @@ class Transcriptions extends Component {
     this.cancelForm = this.cancelForm.bind(this);
     this.refreshAfterSave = this.refreshAfterSave.bind(this);
     this.sortReverse = this.sortReverse.bind(this);
+    this.closeEverything = this.closeEverything.bind(this);
   }
   toggleTransMenu(id, e) {
     e.stopPropagation();
@@ -93,23 +94,18 @@ class Transcriptions extends Component {
       transcriptions: reversed,
     })
   }
-  async componentDidMount() {
-    window.addEventListener('click', () => {
+  closeEverything(e) {
+    if (!e.key || e.key === 'Escape' || e.key === 'Esc') {
       this.setState({
         modalDisplayed: '',
         rowHighlighted: null,
       });
       this.closeAllMenus();
-    });
-    window.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape' || e.key === 'Esc') {
-        this.setState({
-          modalDisplayed: '',
-          rowHighlighted: null,
-        });
-        this.closeAllMenus();
-      }
-    });
+    }
+  }
+  async componentDidMount() {
+    window.addEventListener('click', this.closeEverything);
+    window.addEventListener('keydown', this.closeEverything);
     const confId = this.props.match.params.id;
     const confInfo = await axios.get(`/api/conf/${confId}`);
     const transcriptions = await axios.get(`/api/conf/${confId}/trans`)
@@ -117,6 +113,10 @@ class Transcriptions extends Component {
       confInfo: confInfo.data,
       transcriptions: transcriptions.data,
     });
+  }
+  componentWillUnmount() {
+    window.removeEventListener('click', this.closeEverything);
+    window.removeEventListener('keydown', this.closeEverything);
   }
   render() {
     return (

--- a/client/src/components/Transcriptions.js
+++ b/client/src/components/Transcriptions.js
@@ -180,6 +180,8 @@ class Transcriptions extends Component {
                           <Table.Button
                             onClick={this.toggleTransMenu.bind(this, t.id)}
                             disabled={this.state.modalDisplayed}
+                            forceHighlight={this.state.rowHighlighted === t.id}
+                            allowHighlight={!this.state.rowHighlighted}
                           >
                             &#9776;
                           </Table.Button>

--- a/client/src/components/Transcriptions.js
+++ b/client/src/components/Transcriptions.js
@@ -4,7 +4,7 @@ import DeleteTranscriptionForm from './forms/DeleteTranscriptionForm';
 import { datetime, formatTimeDuration, timeDifference } from '../util/date-format';
 import Main from '../styles/Main';
 import H1 from '../styles/H1';
-import A from '../styles/A';
+import Link from '../styles/Link';
 import Table from '../styles/Table';
 import Menu from '../styles/Menu';
 import Select from '../styles/Select';
@@ -122,7 +122,7 @@ class Transcriptions extends Component {
     return (
       <Main>
         <Header>
-          <A href='/'>&lt; Back to Conferences</A>
+          <Link to='/'>&lt; Back to Conferences</Link>
           {
             this.state.modalDisplayed === 'deleteTranscription'
               ? <DeleteTranscriptionForm
@@ -165,14 +165,14 @@ class Transcriptions extends Component {
                         allowHighlight={!this.state.rowHighlighted}
                       >
                         <Table.Td grow>
-                          <Table.A href={`/conf/${this.props.match.params.id}/trans/${t.id}`}>
+                          <Table.StyledLink to={`/conf/${this.props.match.params.id}/trans/${t.id}`}>
                             {datetime(t.time_start)}
                             {
                               t.time_end
                                 ? ` (${formatTimeDuration(timeDifference(t.time_start, t.time_end))})`
                                 : <Table.Span blue>In Progress</Table.Span>
                             }
-                          </Table.A>
+                          </Table.StyledLink>
                         </Table.Td>
                         <Table.Td>
                           <Table.Button
@@ -184,15 +184,17 @@ class Transcriptions extends Component {
                           {
                             t.showMenu
                               ? <Menu.Menu>
-                                  <Menu.Link as="a" href={`/conf/${this.props.match.params.id}/trans/${t.id}`}>
+                                  <Menu.StyledLink to={`/conf/${this.props.match.params.id}/trans/${t.id}`}>
                                     View transcription
-                                  </Menu.Link>
-                                  <Menu.Link
+                                  </Menu.StyledLink>
+                                  <Menu.StyledLink
+                                    to=""
+                                    as="button"
                                     onClick={this.deleteTranscription.bind(this, t)}
                                     disabled={this.state.modalDisplayed}
                                   >
                                     Delete Transcription
-                                  </Menu.Link>
+                                  </Menu.StyledLink>
                                 </Menu.Menu>
                               : null
                           }

--- a/client/src/components/Utterances.js
+++ b/client/src/components/Utterances.js
@@ -3,7 +3,7 @@ import axios from 'axios';
 import { datetime, timeOnly, dateOnly, timeDifference, isSameDate, formatTimeDuration, formatTimeDurationMMMSS, getTimeOffset } from '../util/date-format';
 import Main from '../styles/Main';
 import H1 from '../styles/H1';
-import A from '../styles/A';
+import Link from '../styles/Link';
 import Button from '../styles/Button';
 import Table from '../styles/Table';
 import Audio from '../styles/Audio';
@@ -200,9 +200,9 @@ class Utterances extends Component {
       <Main noPadding>
         <Header>
           <div>
-            <A href={`/conf/${this.props.match.params.confId}`}>
+            <Link to={`/conf/${this.props.match.params.confId}`}>
               &lt; Back to Conference {this.state.confInfo.meeting_pin}
-            </A>
+            </Link>
             <H1>Transcription</H1>
           </div>
           <DescriptiveTable.Table>

--- a/client/src/components/Utterances.js
+++ b/client/src/components/Utterances.js
@@ -56,6 +56,9 @@ UtterTable.Th = styled(Table.Th)`
   &:nth-child(4) {
     text-align: right;
   }
+  &:nth-child(5) {
+    text-align: right
+  }
   @media (max-width: 700px) {
     padding: 0;
     font-size: 0.9rem;

--- a/client/src/components/forms/AddEditConferenceForm.js
+++ b/client/src/components/forms/AddEditConferenceForm.js
@@ -15,6 +15,7 @@ class AddEditConferenceForm extends Component {
       description: '',
       errorMessage: '',
     }
+    this.setFocus = React.createRef();
     this.handleChange = this.handleChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
     this.handleCancel = this.handleCancel.bind(this);
@@ -63,7 +64,7 @@ class AddEditConferenceForm extends Component {
         title: 'Add a Conference',
       })
     }
-    document.getElementById('meeting_pin').focus();
+    this.setFocus.current.focus();
   }
   render() {
     return (
@@ -84,6 +85,7 @@ class AddEditConferenceForm extends Component {
                     type="text"
                     value={this.state.meeting_pin}
                     onChange={this.handleChange}
+                    ref={this.setFocus}
                   />
                   </td>
                 </Form.Row>

--- a/client/src/components/forms/AddEditConferenceForm.js
+++ b/client/src/components/forms/AddEditConferenceForm.js
@@ -44,8 +44,6 @@ class AddEditConferenceForm extends Component {
       this.props.complete();
     } catch (err) {
       this.setState({ errorMessage: err });
-      console.log(JSON.stringify(err, null, 2));
-      console.log(err.response);
     }
   }
   handleCancel() {

--- a/client/src/components/forms/DeleteConferenceForm.js
+++ b/client/src/components/forms/DeleteConferenceForm.js
@@ -52,7 +52,7 @@ class DeleteConferenceForm extends Component {
             </DescriptiveTable.Table>
             <ErrorMessage>WARNING: This will permanently delete all transcriptions and recordings associated with this conference.</ErrorMessage>
             <ButtonContainer style={{marginTop: '0.7rem'}}>
-              <Button gray onClick={this.handleCancel}>Cancel</Button>
+              <Button gray type="button" onClick={this.handleCancel}>Cancel</Button>
               <Button danger>Delete</Button>
             </ButtonContainer>
           </form>

--- a/client/src/components/forms/DeleteConferenceForm.js
+++ b/client/src/components/forms/DeleteConferenceForm.js
@@ -11,6 +11,7 @@ class DeleteConferenceForm extends Component {
     this.state = {
       errorMessage: '',
     }
+    this.setFocus = React.createRef();
     this.handleChange = this.handleChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
     this.handleCancel = this.handleCancel.bind(this);
@@ -32,6 +33,9 @@ class DeleteConferenceForm extends Component {
   handleCancel() {
     this.props.cancel();
   }
+  componentDidMount() {
+    this.setFocus.current.focus();
+  }
   render() {
     return (
       <Modal.Background>
@@ -52,7 +56,12 @@ class DeleteConferenceForm extends Component {
             </DescriptiveTable.Table>
             <ErrorMessage>WARNING: This will permanently delete all transcriptions and recordings associated with this conference.</ErrorMessage>
             <ButtonContainer style={{marginTop: '0.7rem'}}>
-              <Button gray type="button" onClick={this.handleCancel}>Cancel</Button>
+              <Button
+                gray
+                type="button"
+                onClick={this.handleCancel}
+                ref={this.setFocus}
+              >Cancel</Button>
               <Button danger>Delete</Button>
             </ButtonContainer>
           </form>

--- a/client/src/components/forms/DeleteTranscriptionForm.js
+++ b/client/src/components/forms/DeleteTranscriptionForm.js
@@ -66,7 +66,7 @@ class DeleteTranscriptionForm extends Component {
               }
             </ErrorMessage>
             <ButtonContainer style={{marginTop: '0.7rem'}}>
-              <Button gray onClick={this.handleCancel}>Cancel</Button>
+              <Button gray type="button" onClick={this.handleCancel}>Cancel</Button>
               <Button danger>Delete</Button>
             </ButtonContainer>
 

--- a/client/src/components/forms/DeleteTranscriptionForm.js
+++ b/client/src/components/forms/DeleteTranscriptionForm.js
@@ -12,6 +12,7 @@ class DeleteTranscriptionForm extends Component {
     this.state = {
       errorMessage: '',
     }
+    this.setFocus = React.createRef();
     this.handleChange = this.handleChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
     this.handleCancel = this.handleCancel.bind(this);
@@ -36,6 +37,9 @@ class DeleteTranscriptionForm extends Component {
   }
   handleCancel() {
     this.props.cancel();
+  }
+  componentDidMount() {
+    this.setFocus.current.focus();
   }
   render() {
     return (
@@ -66,7 +70,12 @@ class DeleteTranscriptionForm extends Component {
               }
             </ErrorMessage>
             <ButtonContainer style={{marginTop: '0.7rem'}}>
-              <Button gray type="button" onClick={this.handleCancel}>Cancel</Button>
+              <Button
+                gray
+                type="button"
+                onClick={this.handleCancel}
+                ref={this.setFocus}
+              >Cancel</Button>
               <Button danger>Delete</Button>
             </ButtonContainer>
 

--- a/client/src/styles/Link.js
+++ b/client/src/styles/Link.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
+import { Link } from 'react-router-dom';
 
-const A = styled.a`
+const StyledLink = styled(Link)`
   text-decoration: none;
   color: ${props => props.theme.green}
   &:hover {
@@ -8,4 +9,4 @@ const A = styled.a`
   }
 `;
 
-export default A;
+export default StyledLink;

--- a/client/src/styles/Menu.js
+++ b/client/src/styles/Menu.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { Link } from 'react-router-dom';
 
 const Menu = styled.div`
   position: absolute;
@@ -11,7 +12,7 @@ const Menu = styled.div`
   z-index: 100;
 `;
 
-const Link = styled.button`
+const StyledLink = styled(Link)`
   padding: 0.5rem;
   border: none;
   background: none;
@@ -28,5 +29,5 @@ const Link = styled.button`
 
 export default {
   Menu,
-  Link
+  StyledLink
 };

--- a/client/src/styles/Table.js
+++ b/client/src/styles/Table.js
@@ -96,6 +96,7 @@ const StyledLink = styled(Link)`
 const Button = styled.button`
   display: block;
   height: 3rem;
+  width: 100%;
   padding: 0 1rem;
   border: none;
   background: none;

--- a/client/src/styles/Table.js
+++ b/client/src/styles/Table.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { Link } from 'react-router-dom';
 
 const Table = styled.table`
   margin: 1rem auto;
@@ -77,7 +78,7 @@ const Td = styled.td`
   `}
 `;
 
-const A = styled.a`
+const StyledLink = styled(Link)`
   display: block;
   line-height: 3rem;
   padding: 0 1rem;
@@ -139,7 +140,7 @@ export default {
   Tr,
   Th,
   Td,
-  A,
+  StyledLink,
   Button,
   Span,
 };


### PR DESCRIPTION
Implemented the following changes:

  * replace `<a>` links with react-router `<Link>` (fixes issue where going back didn't refresh content)
  * Remove event listeners when comonents unmount
  * remove highlight when closing modals with the cancel button
  * add `type="button"` to cancel buttons on delete forms to avoid errors
  * utterances table: right-align confidence column (looks bad when no data in table)
  * remove `console.log` from `AddEditConferenceForm`
  * transcriptions table: doesn't show hover styling on button
  * firefox: conference table: button doesn't fill width
  * all modals: set focus with refs (don't use getElementById)
  * delete modals: set focus upon opening